### PR TITLE
Add python ropper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 output/
 cmake/
 .vs/
+scripts/Windows*
+scripts/*.json
+scripts/http.txt

--- a/scripts/download_ntoskrnl.py
+++ b/scripts/download_ntoskrnl.py
@@ -1,0 +1,91 @@
+import os
+import json
+import requests
+import hashlib
+import re
+
+def sanitize_filename(name):
+    # Remove or replace invalid Windows filename characters
+    return re.sub(r'[<>:"/\\|?*+()]', '', name)
+
+def calculate_sha256(filepath):
+    sha256 = hashlib.sha256()
+    try:
+        with open(filepath, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha256.update(chunk)
+        return sha256.hexdigest()
+    except FileNotFoundError:
+        return None
+
+def download_file(url, dest_path):
+    try:
+        response = requests.get(url, stream=True, timeout=60)
+        response.raise_for_status()
+        with open(dest_path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+        return True
+    except requests.RequestException as e:
+        print(f"  [✗] Download failed: {e}")
+        return False
+
+def download_ntoskrnl_files():
+    json_files = [f for f in os.listdir() if f.endswith('.json')]
+
+    for file in json_files:
+        folder_name = os.path.splitext(file)[0]
+
+        if not os.path.exists(folder_name):
+            os.makedirs(folder_name)
+
+        print(f"\n📁 Processing {file}")
+
+        with open(file, 'r', encoding='utf-8') as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                print(f"  [!] Invalid JSON in {file}, skipping.")
+                continue
+
+        for entry in data:
+            if entry.get("Name", "").lower() != "ntoskrnl.exe":
+                continue
+
+            kb = entry.get("KB")
+            version = entry.get("File Version")
+            url = entry.get("Download Link")
+            expected_hash = entry.get("Hash", "").lower()
+
+            if not all([kb, version, url]):
+                print("  [!] Incomplete entry, skipping.")
+                continue
+
+            sanitized_kb = sanitize_filename(kb)
+            sanitized_version = sanitize_filename(version)
+            filename = f"{sanitized_kb}-{sanitized_version}.exe"
+            filepath = os.path.join(folder_name, filename)
+
+            if os.path.exists(filepath):
+                actual_hash = calculate_sha256(filepath)
+                if actual_hash == expected_hash:
+                    print(f"  [✓] Exists and verified: {filename}")
+                    continue
+                else:
+                    print(f"  [↻] Hash mismatch for {filename}, re-downloading...")
+
+            print(f"  [↓] Downloading: {filename}")
+            success = download_file(url, filepath)
+
+            if success:
+                actual_hash = calculate_sha256(filepath)
+                if actual_hash == expected_hash:
+                    print(f"  [✔] Downloaded and verified: {filename}")
+                else:
+                    print(f"  [✗] Hash mismatch after download: {filename} (but file kept)")
+            else:
+                print(f"  [✗] Failed to download: {filename}")
+
+if __name__ == "__main__":
+    download_ntoskrnl_files()

--- a/scripts/find_missing.py
+++ b/scripts/find_missing.py
@@ -1,0 +1,68 @@
+import os
+import json
+import re
+
+def sanitize_filename(text):
+    """Remove illegal filename characters."""
+    return re.sub(r'[^a-zA-Z0-9.\-_]', '', text)
+
+def get_expected_entries(json_file):
+    entries = []
+    try:
+        with open(json_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            for entry in data:
+                if entry.get("Name", "").lower() != "ntoskrnl.exe":
+                    continue
+
+                kb = entry.get("KB", "").strip()
+                version = entry.get("File Version", "").strip()
+                hash_val = entry.get("Hash", "").strip().lower()
+
+                if not kb or not version:
+                    continue
+
+                safe_kb = sanitize_filename(kb)
+                safe_version = sanitize_filename(version)
+                filename = f"{safe_kb}-{safe_version}.exe"
+
+                entries.append({
+                    "filename": filename,
+                    "hash": hash_val
+                })
+    except Exception as e:
+        print(f"[!] Error parsing {json_file}: {e}")
+    return entries
+
+def get_downloaded_filenames(folder):
+    try:
+        return set(f for f in os.listdir(folder) if f.lower().endswith('.exe'))
+    except FileNotFoundError:
+        return None
+
+def find_missing_files():
+    json_files = [f for f in os.listdir() if f.endswith('.json')]
+
+    for json_file in sorted(json_files):
+        folder_name = os.path.splitext(json_file)[0]
+        expected_entries = get_expected_entries(json_file)
+        downloaded_files = get_downloaded_filenames(folder_name)
+
+        print(f"\n📂 {folder_name}")
+
+        if downloaded_files is None:
+            print("  ❌ Folder not found.")
+            continue
+
+        missing = [entry for entry in expected_entries if entry["filename"] not in downloaded_files]
+
+        if not missing:
+            print("  ✅ All files downloaded.")
+        else:
+            print(f"  ⚠️ Missing {len(missing)} file(s):")
+            for entry in missing:
+                print(f"    - {entry['filename']}")
+                print(f"      Hash: {entry['hash']}")
+
+if __name__ == "__main__":
+    find_missing_files()

--- a/scripts/generate_gadgets.py
+++ b/scripts/generate_gadgets.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import os
+import json
+import re
+import subprocess
+import shlex
+from pathlib import Path
+
+# --------------------
+# Configuration
+# --------------------
+ROPPER_CMD = r"C:\Users\krispy\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\Scripts\ropper.exe"             # The ropper executable (must be in PATH)
+ROPPER_NO_COLOR_FLAG = "--nocolor"  # common flag; if not supported ropper output will be sanitized anyway
+TIMEOUT_SECONDS = 300            # per-run timeout for ropper
+# --------------------
+
+ANSI_ESCAPE_RE = re.compile(r'\x1b\[[0-9;]*[mKHFJsu]')
+
+def sanitize_filename(text: str) -> str:
+    """Make a safe filename by removing characters that might be problematic in filenames."""
+    # Keep letters, numbers, dots, hyphen, underscore
+    return re.sub(r'[^A-Za-z0-9.\-_]', '', text)
+
+def find_json_files():
+    return sorted([p for p in os.listdir() if p.endswith('.json')])
+
+def load_json(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def expected_entries_from_json(json_path):
+    """
+    Return list of dicts: { filename: <KB-version.exe>, kb:..., version:..., hash:... }
+    Only entries where Name == ntoskrnl.exe are returned.
+    """
+    out = []
+    try:
+        data = load_json(json_path)
+    except Exception as e:
+        print(f"[!] Failed to parse JSON {json_path}: {e}")
+        return out
+
+    for entry in data:
+        if entry.get("Name", "").lower() != "ntoskrnl.exe":
+            continue
+        kb = entry.get("KB", "").strip()
+        version = entry.get("File Version", "").strip()
+        hash_val = entry.get("Hash", "").strip().lower()
+        if not kb or not version:
+            # skip incomplete entries
+            continue
+        safe_kb = sanitize_filename(kb)
+        safe_ver = sanitize_filename(version)
+        filename = f"{safe_kb}-{safe_ver}.exe"
+        out.append({
+            "filename": filename,
+            "kb": kb,
+            "version": version,
+            "hash": hash_val
+        })
+    return out
+
+def strip_ansi(s: str) -> str:
+    """Remove ANSI escape sequences from a string."""
+    return ANSI_ESCAPE_RE.sub('', s)
+
+def run_ropper_on_file(binary_path: str) -> str:
+    """
+    Runs ropper on binary_path and returns its stdout (with ANSI sequences stripped).
+    Tries to pass a no-color flag; if that fails, still captures output and strips ANSI codes.
+    """
+    attempt_cmds = [
+        [ROPPER_CMD, "-f", binary_path, ROPPER_NO_COLOR_FLAG],  # preferred (if ropper supports)
+        [ROPPER_CMD, "-f", binary_path]                         # fallback
+    ]
+
+    last_exc = None
+    for cmd in attempt_cmds:
+        try:
+            # If any element is empty (e.g. ROPPER_NO_COLOR_FLAG == ""), filter it out
+            cmd = [c for c in cmd if c]
+            # Run and capture stdout
+            completed = subprocess.run(cmd,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       text=True,
+                                       timeout=TIMEOUT_SECONDS)
+            # Prefer stdout; if empty maybe stderr contains info (some ropper versions print to stderr)
+            output = completed.stdout if completed.stdout else completed.stderr
+            return strip_ansi(output)
+        except FileNotFoundError as e:
+            last_exc = e
+            break  # ropper not installed
+        except subprocess.TimeoutExpired as e:
+            last_exc = e
+            print(f"[!] ropper timed out for {binary_path}")
+            break
+        except Exception as e:
+            last_exc = e
+            # try next variant
+            continue
+
+    # If we get here, ropper failed to run
+    raise RuntimeError(f"failed to run ropper (last error: {last_exc})")
+
+def ensure_gadgets_dir(parent_dir: str) -> str:
+    gadgets_dir = os.path.join(parent_dir, "Gadgets")
+    os.makedirs(gadgets_dir, exist_ok=True)
+    return gadgets_dir
+
+def main():
+    json_files = find_json_files()
+    if not json_files:
+        print("No .json files found in current directory.")
+        return
+
+    print(f"Found {len(json_files)} json file(s).")
+    for j in json_files:
+        parent_dir = os.path.splitext(j)[0]  # e.g., Windows10-22h2
+        expected = expected_entries_from_json(j)
+        if not expected:
+            print(f"\n[{parent_dir}] No ntoskrnl.exe entries found; skipping.")
+            continue
+
+        gadgets_dir = ensure_gadgets_dir(parent_dir)
+        print(f"\n[{parent_dir}] Generating gadgets for {len(expected)} file(s). Output dir: {gadgets_dir}")
+
+        for entry in expected:
+            exe_name = entry["filename"]
+            exe_path = os.path.join(parent_dir, exe_name)
+            out_name = f"{os.path.splitext(exe_name)[0]}.gadgets.txt"
+            out_path = os.path.join(gadgets_dir, out_name)
+
+            if not os.path.isfile(exe_path):
+                print(f"  - Missing binary: {exe_path}  (skipping)")
+                continue
+
+            # If gadget file already exists, skip (user did not ask to regenerate)
+            if os.path.isfile(out_path):
+                print(f"  - Gadget file exists: {out_name} (skipping)")
+                continue
+
+            print(f"  - Running ropper on: {exe_name} ...", end=' ', flush=True)
+            try:
+                ropper_output = run_ropper_on_file(exe_path)
+            except RuntimeError as e:
+                print(f"\n    [ERROR] {e}")
+                continue
+            except Exception as e:
+                print(f"\n    [ERROR] unexpected error: {e}")
+                continue
+
+            # Save output without color (we already stripped ANSI sequences)
+            try:
+                with open(out_path, 'w', encoding='utf-8') as fo:
+                    fo.write(ropper_output)
+                print("done.")
+            except Exception as e:
+                print(f"\n    [ERROR] Failed to write {out_path}: {e}")
+
+    print("\nAll done.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_count.py
+++ b/scripts/get_count.py
@@ -1,0 +1,48 @@
+import os
+import json
+from time import sleep
+
+def count_expected_files(json_file):
+    try:
+        with open(json_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            # Only count entries for ntoskrnl.exe (or all if you prefer)
+            return sum(1 for entry in data if entry.get("Name", "").lower() == "ntoskrnl.exe")
+    except Exception as e:
+        print(f"[!] Error reading {json_file}: {e}")
+        return 0
+
+def count_downloaded_files(folder):
+    try:
+        return len([f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))])
+    except FileNotFoundError:
+        return 0
+
+def show_progress_bar(current, total, width=40):
+    if total == 0:
+        bar = '[ No data ]'
+    else:
+        progress = current / total
+        filled = int(progress * width)
+        bar = '[' + '#' * filled + '-' * (width - filled) + f'] {current}/{total} ({progress*100:.1f}%)'
+    return bar
+
+def monitor_download_progress():
+    json_files = [f for f in os.listdir() if f.endswith('.json')]
+
+    print("\n🔍 Monitoring Download Progress...\n")
+
+    for json_file in sorted(json_files):
+        folder_name = os.path.splitext(json_file)[0]
+        expected_count = count_expected_files(json_file)
+        downloaded_count = count_downloaded_files(folder_name)
+
+        bar = show_progress_bar(downloaded_count, expected_count)
+        print(f"{folder_name.ljust(30)} {bar}")
+
+if __name__ == "__main__":
+    while True:
+        os.system('cls' if os.name == 'nt' else 'clear')
+        monitor_download_progress()
+        sleep(1)
+

--- a/scripts/scrape_winbindex.py
+++ b/scripts/scrape_winbindex.py
@@ -1,0 +1,87 @@
+import re
+import json
+from bs4 import BeautifulSoup
+
+# To get the HTML content, just visit winbindex, set it to show 100 entries per page, and then
+# in the console, just run copy(document.documentElement.outerHTML)
+# that way you store it after JS modifications
+# After that, just paste it into a file named http.txt
+
+# The name of your input file is http.txt
+input_filename = 'http.txt'
+# The name of the file to store the extracted data in JSON format
+output_filename = 'extracted-data.json'
+
+def extract_and_store_data(html_file, output_file):
+    """
+    Extracts download links and related information from an HTML file and stores it in a JSON file.
+
+    Args:
+        html_file (str): The path to the input HTML file.
+        output_file (str): The path to the output JSON file where the extracted data will be stored.
+    """
+    try:
+        with open(html_file, 'r', encoding='utf-8') as f:
+            html_content = f.read()
+
+        soup = BeautifulSoup(html_content, 'html.parser')
+        table = soup.find('table', id='winbindex-table')
+
+        if not table:
+            print("Error: Could not find the table with id 'winbindex-table'.")
+            return
+
+        table_body = table.find('tbody')
+        if not table_body:
+            print("Error: Could not find the table body.")
+            return
+
+        rows = table_body.find_all('tr')
+        extracted_data = []
+
+        for row in rows:
+            cols = row.find_all('td')
+            if len(cols) >= 8:
+                # Extract SHA256 hash from the 'title' attribute of the first 'a' tag
+                hash_link = cols[0].find('a')
+                sha256_hash = ''
+                if hash_link and 'title' in hash_link.attrs:
+                    title_text = hash_link['title']
+                    # Use regex to find the SHA256 hash
+                    match = re.search(r'([a-fA-F0-9]{64})', title_text)
+                    if match:
+                        sha256_hash = match.group(1)
+
+                # Extract KB number from the 'title' attribute of the 'abbr' tag
+                kb_abbr = cols[2].find('abbr')
+                kb_number = kb_abbr.get_text(strip=True) if kb_abbr else 'N/A'
+
+                # Extract File Version
+                file_version = cols[4].get_text(strip=True)
+
+                # Extract Download Link
+                download_link_tag = cols[7].find('a')
+                download_link = download_link_tag['href'] if download_link_tag else 'N/A'
+
+                data = {
+                    "Name": "ntoskrnl.exe",
+                    "KB": kb_number,
+                    "Hash": sha256_hash,
+                    "File Version": file_version,
+                    "Download Link": download_link
+                }
+                extracted_data.append(data)
+
+        # Write the extracted data to a JSON file with pretty formatting
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(extracted_data, f, indent=4)
+
+        print(f"Data successfully extracted and stored in JSON file '{output_file}'")
+
+    except FileNotFoundError:
+        print(f"Error: The file '{html_file}' was not found.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+# Run the extraction function
+extract_and_store_data(input_filename, output_filename)

--- a/scripts/search_gadgets.py
+++ b/scripts/search_gadgets.py
@@ -1,0 +1,195 @@
+
+from __future__ import annotations
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+def find_release_dirs(base_dir: Path) -> List[Path]:
+    """Return sorted list of immediate subdirectories in base_dir."""
+    dirs = [p for p in sorted(base_dir.iterdir()) if p.is_dir()]
+    return dirs
+
+def find_gadget_files(release_dir: Path) -> List[Path]:
+    """Find all *.gadgets.txt files under release_dir/Gadgets/."""
+    gadgets_dir = release_dir / "Gadgets"
+    if not gadgets_dir.exists() or not gadgets_dir.is_dir():
+        return []
+    return sorted(gadgets_dir.glob("*.gadgets.txt"))
+
+def compile_pattern(query: str, regex: bool, ignore_case: bool):
+    flags = re.MULTILINE
+    if ignore_case:
+        flags |= re.IGNORECASE
+    if regex:
+        try:
+            return re.compile(query, flags)
+        except re.error as e:
+            print(f"[ERROR] invalid regular expression: {e}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        # escape the query for a literal search
+        return re.compile(re.escape(query), flags)
+
+def search_file_for_pattern(path: Path, pattern: re.Pattern, context: int = 0) -> List[Dict]:
+    """
+    Search a file for pattern. Return list of matches.
+    Each match dict: {'line_no': int, 'line': str, 'context_before': [str], 'context_after': [str]}
+    """
+    try:
+        text = path.read_text(encoding='utf-8', errors='replace')
+    except Exception as e:
+        return [{"error": f"failed to read file: {e}"}]
+
+    lines = text.splitlines()
+    matches = []
+
+    for i, line in enumerate(lines):
+        if pattern.search(line):
+            start = max(0, i - context)
+            end = min(len(lines), i + context + 1)
+            matches.append({
+                "line_no": i + 1,
+                "line": line,
+                "context_before": lines[start:i],
+                "context_after": lines[i+1:end]
+            })
+    return matches
+
+def human_path(p: Path) -> str:
+    return str(p)
+
+def print_match(path: Path, match: Dict, highlight: bool = False):
+    """Print a single match with context."""
+    # No color highlighting by default (user requested no color-preservation)
+    for bline in match.get("context_before", []):
+        print(f"    {bline}")
+    print(f"  -> {match['line_no']:5d}: {match['line']}")
+    for aline in match.get("context_after", []):
+        print(f"    {aline}")
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Search gadget files under each release's Gadgets/ folder.")
+    ap.add_argument("query", help="Gadget string to search for (literal by default). Example: \"push rcx; pop rsp;\"")
+    ap.add_argument("--base-dir", "-b",
+                    default=r"C:\Users\krispy\Documents\roprw\scripts",
+                    help="Base directory containing release folders (default matches your path).")
+    ap.add_argument("--regex", "-r", action="store_true", help="Treat query as a regular expression.")
+    ap.add_argument("--ignore-case", "-i", action="store_true", help="Case-insensitive search.")
+    ap.add_argument("--context", "-c", type=int, default=0, help="Number of context lines to show before/after each match.")
+    ap.add_argument("--show-missing-only", action="store_true", help="Only print items where the gadget is missing.")
+    ap.add_argument("--summary-only", action="store_true", help="Print a compact summary at the end.")
+    ap.add_argument("--max-per-file", type=int, default=50, help="Max matches shown per file (0 = show all).")
+    ap.add_argument("--version", "-v", help="Scan only a specific version folder (e.g. Windows11-22h2)")
+    args = ap.parse_args(argv)
+
+    base_dir = Path(args.base_dir).expanduser()
+    if not base_dir.exists() or not base_dir.is_dir():
+        print(f"[ERROR] base directory does not exist or is not a directory: {base_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    pattern = compile_pattern(args.query, regex=args.regex, ignore_case=args.ignore_case)
+
+    # Support filtering by version
+    if args.version:
+        release_dirs = [base_dir / args.version]
+        if not release_dirs[0].exists():
+            print(f"[ERROR] Specified version folder does not exist: {release_dirs[0]}")
+            sys.exit(1)
+    else:
+        release_dirs = find_release_dirs(base_dir)
+
+    if not release_dirs:
+        print(f"No release directories found in {base_dir}")
+        return
+
+    overall_summary = {}  # release -> { 'files_total':n, 'files_with_match': [file1,..], 'files_without_match':[...], 'gadgets_dir_missing':bool }
+
+    for rel in release_dirs:
+        gadget_files = find_gadget_files(rel)
+        rel_summary = {
+            "gadgets_dir_missing": False,
+            "files_total": 0,
+            "files_with_match": [],
+            "files_without_match": []
+        }
+
+        if not gadget_files:
+            # no Gadgets directory or no gadget files
+            gadgets_dir = rel / "Gadgets"
+            if not gadgets_dir.exists():
+                rel_summary["gadgets_dir_missing"] = True
+                overall_summary[str(rel)] = rel_summary
+                if not args.summary_only:
+                    print(f"\n[ {rel.name} ]  -> Gadgets/ folder missing.")
+                continue
+            else:
+                # Gadgets exists but no files
+                rel_summary["files_total"] = 0
+                overall_summary[str(rel)] = rel_summary
+                if not args.summary_only:
+                    print(f"\n[ {rel.name} ]  -> Gadgets/ folder empty (no *.gadgets.txt files).")
+                continue
+
+        rel_summary["files_total"] = len(gadget_files)
+
+        if not args.summary_only:
+            print(f"\n[ {rel.name} ]  Searching {len(gadget_files)} gadget file(s) in {rel / 'Gadgets'}")
+
+        for gf in gadget_files:
+            matches = search_file_for_pattern(gf, pattern, context=args.context)
+            # if read error
+            if matches and isinstance(matches[0], dict) and "error" in matches[0]:
+                # treat as missing but report error
+                rel_summary["files_without_match"].append((gf, matches[0]["error"]))
+                if not args.summary_only and not args.show_missing_only:
+                    print(f"  - {gf.name}: ERROR reading file: {matches[0]['error']}")
+                continue
+
+            if not matches:
+                rel_summary["files_without_match"].append((gf, None))
+                if not args.summary_only and args.show_missing_only:
+                    print(f"  - MISSING in {gf.name}")
+                elif not args.summary_only and not args.show_missing_only:
+                    # keep behavior: don't print every missing unless requested — but user wanted to print where missing, so print
+                    print(f"  - {gf.name}: no match")
+            else:
+                rel_summary["files_with_match"].append((gf, matches))
+                if not args.summary_only and not args.show_missing_only:
+                    print(f"  - {gf.name}: {len(matches)} match(es)")
+                    shown = 0
+                    for m in matches:
+                        if args.max_per_file and shown >= args.max_per_file:
+                            print(f"    ... (more matches hidden, increase --max-per-file)")
+                            break
+                        print_match(gf, m)
+                        shown += 1
+
+        overall_summary[str(rel)] = rel_summary
+
+    # Print compact summary if requested or always print missing files summary
+    print("\n\n===== SUMMARY =====\n")
+    for rel_name, s in overall_summary.items():
+        relp = Path(rel_name)
+        print(f"{relp.name}: ", end='')
+        if s.get("gadgets_dir_missing"):
+            print("Gadgets/ missing")
+            continue
+        total = s.get("files_total", 0)
+        with_match = len(s.get("files_with_match", []))
+        without = len(s.get("files_without_match", []))
+        print(f"{with_match}/{total} files contain the gadget, {without} do not.")
+        if without:
+            print("  Missing in:")
+            for gf, err in s["files_without_match"]:
+                if err:
+                    print(f"    - {gf.name} (ERROR: {err})")
+                else:
+                    print(f"    - {gf.name}")
+        # small spacer
+        print()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds some scripts, you can now parse the winbindex page to get the download links, you can also use the downloading script to download all ntos versions, and the gadget search script to look for a gadget for example:
`python3 .\search_gadgets.py -r "push rsp; pop rsp; adc eax, [^;]+; ret;" --version Windows10-22h2`
or don't specify `--version` to look through all versions.