### PR TITLE
Fix event name heap corruption

### DIFF
--- a/src/rop_thread/memory_manager.cpp
+++ b/src/rop_thread/memory_manager.cpp
@@ -3,14 +3,19 @@
 
 void MemoryManager::AllocateMemory()
 {
+    const wchar_t* UmEventNameString = UM_EVENT_NAME;
+    const wchar_t* KmEventNameString = KM_EVENT_NAME;
+    const int UmEventNameStringLength = (lstrlenW(UmEventNameString) + 1) * sizeof(WCHAR);
+    const int KmEventNameStringLength = (lstrlenW(KmEventNameString) + 1) * sizeof(WCHAR);
+
     KernelSharedMemoryAllocation = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", sizeof(SharedMemoryData), reinterpret_cast<void*>(MAXULONG64));
     PivotDataAllocation = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", sizeof(PivotData), reinterpret_cast<void*>(MAXULONG64));
     UmDestinationStringArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));
-    UmSourceStringArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));
+    UmSourceStringArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", UmEventNameStringLength, reinterpret_cast<void*>(MAXULONG64));
     UmObjectAttributeArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", sizeof(OBJECT_ATTRIBUTES), reinterpret_cast<void*>(MAXULONG64));
     UmOutputHandleArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));
     KmDestinationStringArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));
-    KmSourceStringArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));
+    KmSourceStringArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", KmEventNameStringLength, reinterpret_cast<void*>(MAXULONG64));
     KmObjectAttributeArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", sizeof(OBJECT_ATTRIBUTES), reinterpret_cast<void*>(MAXULONG64));
     KmOutputHandleArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));
     GameEProcessOutputArg = KernelCaller.Call<void*, std::size_t, void*>("MmAllocateContiguousMemory", 0x8, reinterpret_cast<void*>(MAXULONG64));


### PR DESCRIPTION
This adds code which calculates the string sizes instead of allocating a pool of hard coded size 8.