### PR TITLE
Thread safe usermode requests

### DIFF
--- a/include/rop_thread/rop_thread.hpp
+++ b/include/rop_thread/rop_thread.hpp
@@ -2,6 +2,7 @@
 #include <include/rop_thread/stack_manager.hpp>
 #include <include/rop_thread/memory_manager.hpp>
 #include <include/driver/arbitrary_call.hpp>
+#include <mutex>
 
 class RopThreadManager
 {
@@ -13,6 +14,7 @@ private:
 	SharedMemoryData* SharedMemory = nullptr;
 	HANDLE KmEvent = INVALID_HANDLE_VALUE;
 	HANDLE UmEvent = INVALID_HANDLE_VALUE;
+	std::mutex PacketMutex;
 	void BuildInitStack(StackManager* Stack, StackManager* PivotStack, const SharedMemoryData* SharedMem);
 	void BuildMainStack(StackManager* Stack, const SharedMemoryData* SharedMem);
 	void CreateEventObjects();

--- a/src/rop_thread/rop_thread.cpp
+++ b/src/rop_thread/rop_thread.cpp
@@ -122,12 +122,14 @@ void RopThreadManager::SpawnThread()
 
 void RopThreadManager::SendTargetProcessPid(const int TargetPid)
 {
+    std::lock_guard<std::mutex> Lock(PacketMutex);
     SharedMemory->TargetPid = TargetPid;
     SendPacket();
 }
 
 void RopThreadManager::SendReadRequest(const std::uint64_t SourceAddress, const std::uint64_t DestAddress, const std::size_t Size)
 {
+    std::lock_guard<std::mutex> Lock(PacketMutex);
     SharedMemory->WriteSrcEProcess = SharedMemory->GameEProcess;
     SharedMemory->WriteDstEProcess = SharedMemory->CheatEProcess;
     SharedMemory->WriteSrcAddress = SourceAddress;
@@ -138,6 +140,7 @@ void RopThreadManager::SendReadRequest(const std::uint64_t SourceAddress, const 
 
 void RopThreadManager::SendWriteRequest(const std::uint64_t SourceAddress, const std::uint64_t DestAddress, const std::size_t Size)
 {
+    std::lock_guard<std::mutex> Lock(PacketMutex);
     SharedMemory->WriteSrcEProcess = SharedMemory->CheatEProcess;
     SharedMemory->WriteDstEProcess = SharedMemory->GameEProcess;
     SharedMemory->WriteSrcAddress = SourceAddress;


### PR DESCRIPTION
## Summary
- Adds a `std::mutex` to `RopThreadManager` that serializes access to the UM-KM shared memory buffer
- `SendReadRequest`, `SendWriteRequest`, and `SendTargetProcessPid` now acquire the lock before writing to `SharedMemory` and releasing it after `SendPacket()` returns
- Prevents race conditions when multiple usermode threads issue concurrent r/w requests

Closes #32